### PR TITLE
Allow alternative endpoint for updates.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -29,12 +29,18 @@ var SparqlClient = module.exports = function SparqlClient(endpoint, options) {
     };
     var doRequest = promise.denodeify(request.defaults(requestDefaults));
 
+    var updateEndpoint = endpoint;
+    if (options && options.updateEndpoint) {
+        updateEndpoint = options.updateEndpoint;
+        delete options.updateEndpoint;
+    }
+
     var that = this;
 
     var sparqlRequest = function sparqlRequest(query, queryOptions) {
         var requestBody =
             (query.isUpdate) ?
-                { update: query.text } :
+                { update: query.text, url: updateEndpoint } :
                 { query: query.text };
         _.defaults(requestBody, defaultParameters);
 


### PR DESCRIPTION
This change allows the client to be used with endpoints that require updates on a different Sparql endpoint.

The server I am using is Ontotext's GraphDB which does not execute update queries on the default endpoint.
