### PR TITLE
Allow Sparql endpoint to return no body.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -55,12 +55,21 @@ var SparqlClient = module.exports = function SparqlClient(endpoint, options) {
                     throw error;
                 }
 
-                responseBody = JSON.parse(response.body);
+                responseBody = parseJSON(response.body);
 
                 if (queryOptions) {
                     formatter.format(responseBody, queryOptions);
                 }
                 return promise.resolve(responseBody);
+
+                function parseJSON(body) {
+                    // Catch invalid JSON
+                    try {
+                        return JSON.parse(response.body);
+                    } catch( ex ) {
+                        return null;
+                    }
+                }
 
                 function formatErrorMessage(res) {
                     var code = res.statusCode;

--- a/spec/primary-api-spec.js
+++ b/spec/primary-api-spec.js
@@ -637,6 +637,23 @@ describe('SPARQL API', function () {
           });
       });
 
+      it('should allow for empty response bodies', function (done) {
+        var queryScope = nockEndpoint(204, ' ');
+
+        var client = new SparqlClient(queryScope.endpoint);
+
+        // The query
+        client.query('INSERT DATA { pkmn:Lotad pkdx:evolvesTo pkmn:Lombre }')
+          .execute()
+          .then(function (results) {
+            expect(results).toBeNull();
+            done();
+          })
+          .catch(function (err) {
+            fail(err);
+          });
+      });
+
       it('should return a error message on request failure', function (done) {
         /* Based on
          * https://www.w3.org/TR/rdf-sparql-protocol/#select-malformed


### PR DESCRIPTION
Allow empty response body as a result to update queries.

https://www.w3.org/TR/2013/REC-sparql11-http-rdf-update-20130321/#http-post
