### PR TITLE
Allow override of request defaults and params

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,34 @@ client.query(SPARQL`
   });
 ```
 
+### Overriding request defaults
+
+You can override the request defaults by passing them in the options object of the constructor. `defaultParams` are the default parameters in the request, and `requestsDefaults` are the default _request options_. This distinction is a little confusing, so here're some examples:
+
+For example, say you have a graph database that expects `format: 'json'` as a param rather than the default `format: 'application/sparql-results+json'`. You can override the default when constructing your client like so:
+
+```js
+var client = new SparqlClient('http://example.org/query', {
+  defaultParameters: {
+    format: 'json'
+  }
+});
+```
+
+Similarly, let's say you want to specify your client's user agent string. You can pass this, and other headers, as part of a `requestsDefaults` option.
+
+```js
+var client = new SparqlClient('http://example.org/query', {
+  requestsDefaults: {
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'Accept': 'application/sparql-results+json,application/json',
+      'User-Agent': 'My Totally Sweet App - 1.0'
+    }
+  }
+});
+```
+
 ## Errors
 
 If an error occurs, such as when submitting a query with a syntax error,

--- a/lib/client.js
+++ b/lib/client.js
@@ -27,6 +27,15 @@ var SparqlClient = module.exports = function SparqlClient(endpoint, options) {
         format: 'application/sparql-results+json',
         'content-type': 'application/sparql-results+json'
     };
+    
+    if (options && options.requestDefaults) {
+        Object.assign(requestDefaults, options.requestDefaults);
+    }
+    if (options && options.defaultParameters) {
+        Object.assign(defaultParameters, options.defaultParameters);
+    }
+
+    
     var doRequest = promise.denodeify(request.defaults(requestDefaults));
 
     var updateEndpoint = endpoint;


### PR DESCRIPTION
So now you can do things like

``` js
const client =
          new SparqlClient(ENV.sparqlURL, {defaultParameters: {format: 'json'}})
          .register({
              'voaf': 'http://purl.org/vocommons/voaf#',
              'dct': 'http://purl.org/dc/terms/',
              'vann': 'http://purl.org/vocab/vann/',
              'skos': 'http://www.w3.org/2004/02/skos/core#'
          });
```

for things like Blazegraph, which expect 'json' as the format (for some reason). Also overriding the user-agent etc could be useful.
