### PR TITLE
Fix IRIREF regex; resolves #8.

### DIFF
--- a/lib/iri.js
+++ b/lib/iri.js
@@ -10,48 +10,50 @@ module.exports = IRI;
  * Base IRI.
  */
 function IRI() {
-    Term.call(this);
+  Term.call(this);
 }
 
 IRI.prototype = Object.create(Term.prototype, {
-    type: { value: 'uri', enumerable: true }
+  type: { value: 'uri', enumerable: true }
 });
 
 /**
  * Returns an IRI for whatever is passed in.
  */
 IRI.create = function (value) {
-    if (typeof value === 'object') {
-        return IRI.createFromObject(value);
-    } else if (typeof value === 'string') {
-        return new IRIReference(value);
-    } else {
-        throw new TypeError('Invalid IRI');
-    }
+  if (typeof value === 'object') {
+    return IRI.createFromObject(value);
+  } else if (typeof value === 'string') {
+    return new IRIReference(value);
+  } else {
+    throw new TypeError('Invalid IRI');
+  }
 };
 
 /**
  * Returns an IRI object or null if none can be created.
  */
 IRI.createFromObject = function (object) {
-    var namespace, value, keys = Object.keys(object);
-    if (keys.length != 1) {
-        throw new Error('Invalid prefixed IRI.');
-    }
+  var namespace;
+  var value;
+  var keys = Object.keys(object);
+  if (keys.length !== 1) {
+    throw new Error('Invalid prefixed IRI.');
+  }
 
-    namespace = keys[0];
-    value = object[namespace];
+  namespace = keys[0];
+  value = object[namespace];
 
-    if (typeof value !== 'string') {
-        throw new TypeError('Invalid prefixed IRI.');
-    }
+  if (typeof value !== 'string') {
+    throw new TypeError('Invalid prefixed IRI.');
+  }
 
-    /* TODO: This is NOT a sufficient regex! */
-    if (!/^[^\s;.,<|$]+$/.test(value)) {
-        throw new Error('Invalid IRI identifier');
-    }
+  /* TODO: This is NOT a sufficient regex! */
+  if (!/^[^\s;.,<|$]+$/.test(value)) {
+    throw new Error('Invalid IRI identifier');
+  }
 
-    return new PrefixedNameIRI(namespace, value);
+  return new PrefixedNameIRI(namespace, value);
 };
 
 /**
@@ -61,20 +63,20 @@ IRI.createFromObject = function (object) {
  * :book1
  */
 function PrefixedNameIRI(namespace, identifier) {
-    IRI.call(this);
-    this.namespace = namespace;
-    this.id = identifier;
+  IRI.call(this);
+  this.namespace = namespace;
+  this.id = identifier;
 }
 
 PrefixedNameIRI.prototype = Object.create(IRI.prototype, {
-    value: {
-        get: function () { return 'INVALID!' + this.format(); },
-        enumerable: true
-    }
+  value: {
+    get: function () { return 'INVALID!' + this.format(); },
+    enumerable: true
+  }
 });
 
 PrefixedNameIRI.prototype.format = function () {
-    return this.namespace + ':' + this.id;
+  return this.namespace + ':' + this.id;
 };
 
 /**
@@ -83,21 +85,22 @@ PrefixedNameIRI.prototype.format = function () {
  * <http://example.org/book/book1> or <book1>.
  */
 function IRIReference(iri) {
-    IRI.call(this);
-    /* IRIREF is defined here:
-     * http://www.w3.org/TR/2013/REC-sparql11-query-20130321/#rIRIREF
-     */
-    if (!/^[^<>"{}|^`\]\-[\u0000-\u0020]*$/.test(iri)) {
-        throw new Error('Invalid IRI (not shown)');
-    }
-    this.iri = iri;
+  IRI.call(this);
+  /*
+   * IRIREF is defined here:
+   * http://www.w3.org/TR/2013/REC-sparql11-query-20130321/#rIRIREF
+   */
+  if (!/^[^<>"{}|^`\\\u0000-\u0020]*$/.test(iri)) {
+    throw new Error('Invalid IRI: ' + iri);
+  }
+  this.iri = iri;
 }
 
 IRIReference.prototype = Object.create(IRI.prototype, {
-    value: { get: function () { return this.iri; }, enumerable: true }
+  value: { get: function () { return this.iri; }, enumerable: true }
 });
 
 IRIReference.prototype.format = function () {
-    return '<' + this.iri + '>';
+  return '<' + this.iri + '>';
 };
 

--- a/spec/regressions-spec.js
+++ b/spec/regressions-spec.js
@@ -52,7 +52,7 @@ describe('GitHub Issues', function () {
             });
         });
 
-      function replyWithArgsPresent (uri, body) {
+      function replyWithArgsPresent(uri, body) {
         return {
           update: !!body.match(/update=/),
           query: !!body.match(/query=/)
@@ -62,21 +62,23 @@ describe('GitHub Issues', function () {
   });
 
   describe('#8', function () {
-    it('should not crash on HTTP response error', function (done) {
-      var host = 'http://example.org';
-      var endpoint = 'http://example.org/sparql';
+    it('should accept dashes in IRIs', function (done) {
+      var scope = nockEndpoint();
+      var query = new SparqlClient(scope.endpoint)
+        .query('ASK { [] ex:v1 ?literal ; [] ex:v1 ?lateral }');
 
-      nock(host)
-        .post('/sparql')
-        .reply(503, { result: {} });
+      // This IRI has a dash in it:
+      query.bind('literal', 'http://example.org/this-is-valid', {type: 'uri'});
+      // This is an internationalized URI, with dashes!
+      query.bind('literal', 'http://💩.la/this-is-valid', {type: 'uri'});
 
-      var client = new SparqlClient(endpoint);
-      client
-        .query('SELECT ("hello" as ?var) { }')
-        .execute(function (err, _response) {
-          expect(err).toBeTruthy();
-          done();
-        });
+      query.execute(function (error, data) {
+        expect(error).toBeFalsy();
+        expect(data).toBeTruthy();
+        done();
+      });
     });
   });
 });
+
+/* global nockEndpoint */


### PR DESCRIPTION
@paulwilton,

I believe I misinterpreted the [EBNF] character range syntax here. This is the the rule I was trying to transcribe in JavaScript's regular expressions: https://www.w3.org/TR/2013/REC-sparql11-query-20130321/#rIRIREF

[EBNF]: https://www.w3.org/TR/2004/REC-xml11-20040204/#sec-notation

I adjusted the regex in IRI to allow dashes, and to disallow backslashes.

Let me know if this makes sense.