### PR TITLE
Newline and other escaping fix

### DIFF
--- a/lib/term/literal.js
+++ b/lib/term/literal.js
@@ -87,13 +87,20 @@ function assertSafeString(value) {
 }
 
 /**
- * Escapes all special characters in a string, except for linefeeds (U+000A).
+ * Escapes all special characters in a string.
  */
+var escapeCharacterMapping = {
+    '\t': 't',
+    '\n': 'n',
+    '\r': 'r',
+    '\b': 'b',
+    '\f': 'f'
+};
 function escapeString(str) {
     /* From: http://www.w3.org/TR/2013/REC-sparql11-query-20130321/#grammarEscapes */
-    /* This omits newline. */
-    var escapableCodePoints = /[\\\u0009\u000D\u0008\u000C\u0022\u0027]/g;
+    var escapableCodePoints = /[\\'"\t\n\r\b\f]/g;
     return str.replace(escapableCodePoints, function (character) {
+        character = escapeCharacterMapping[character] || character;
         return '\\' + character;
     });
 }
@@ -106,7 +113,7 @@ function formatString(value) {
     var escaped = escapeString(stringified);
     var hasSingleQuote = /'/.test(stringified);
     var hasDoubleQuote = /"/.test(stringified);
-    var hasNewline = /"/.test(stringified);
+    var hasNewline = /\n/.test(stringified);
 
     var delimiter;
 

--- a/spec/primary-api-spec.js
+++ b/spec/primary-api-spec.js
@@ -437,12 +437,13 @@ describe('SPARQL API', function () {
         var scope = nockEndpoint();
         var query = new SparqlClient(scope.endpoint)
           .query('SELECT ?s {?s rdfs:label ?value}')
-          .bind('value', '"""' + "'''" + "\n" + "\\");
+        // NOTE: Escaped characters list: https://www.w3.org/TR/sparql11-query/#grammarEscapes
+          .bind('value', '"""' + "'''" + "\t\n\r\b\f" + "\\");
 
         query.execute(function (error, data) {
           var query = data.request.query;
           /* I applogize for this regex... */
-          expect(query).toMatch(/rdfs:label\s+('''|""")\\"\\"\\"\\'\\'\\'\n\\\\\1/);
+          expect(query).toMatch(/rdfs:label\s+('''|""")\\"\\"\\"\\'\\'\\'\\t\\n\\r\\b\\f\\\\\1/);
           done();
         });
       });


### PR DESCRIPTION
One weird thing is, for some reason, comments and tests were deliberate about **not** escaping "\n", but the spec says they should be, and the spec is referenced in the comments.

The "except for linefeeds" comment came from 79525e44bde3b0a5fc12bb29033bdf8a67879dfb authored by @eddieantonio, If newline thing was deliberate, please explain why.

I got errors about `\n` from blazegraph (that's what led me to this PR).
```
java.util.concurrent.ExecutionException: org.openrdf.query.MalformedQueryException: Lexical error at line 15, column 26.  Encountered: "\n" (10), after : "\'XXX - "
```